### PR TITLE
Set the SplashText text alignment to the center

### DIFF
--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -20,6 +20,7 @@
         android:layout_alignParentBottom="true"
         android:layout_centerHorizontal="true"
         android:layout_marginBottom="32dp"
+        android:textAlignment="center"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:textColor="@color/secondaryTextColor" />
 


### PR DESCRIPTION
Set the SplashText text alignment to the center.
I made this PR, because on not very large devices SplashText is transferred and aligned to the left edge, which does not look nice.